### PR TITLE
exporter container added, exporter default values added

### DIFF
--- a/templates/clusterRoleBinding.yaml
+++ b/templates/clusterRoleBinding.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: skydive-default-view
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin 
+subjects:
+  - kind: ServiceAccount
+    name: skydive-service-account
+    namespace: {{ .Release.Namespace }}

--- a/templates/deployment-agents.yaml
+++ b/templates/deployment-agents.yaml
@@ -21,14 +21,18 @@ spec:
         heritage: "{{ .Release.Service }}"
         tier: agent
     spec:
+      serviceAccountName: skydive-service-account
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      hostPID: true
+      hostIPC: true
       securityContext:
         runAsNonRoot: false
       affinity:
         {{- include "nodeaffinity" . | indent 6 }}
       tolerations:
       - operator: "Exists"
+      hostNetwork: true
       {{- if .Values.image.secretName }}
       {{- if ne .Values.image.secretName ""}}
       imagePullSecrets:
@@ -74,6 +78,11 @@ spec:
       {{- if .Values.env }}
 {{ toYaml .Values.env | indent 8 }}
       {{- end }}
+{{- if .Values.exporter.enabled }}
+  {{- if .Values.exporter.env }}
+{{ toYaml .Values.exporter.env | indent 8 }}
+  {{- end }}
+{{- end }}
         securityContext:
           privileged: true
           readOnlyRootFilesystem: false

--- a/templates/deployment-analyzer.yaml
+++ b/templates/deployment-analyzer.yaml
@@ -23,7 +23,13 @@ spec:
         tier: analyzer
     spec:
       serviceAccountName: skydive-service-account
+      hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      hostPID: true
+      hostIPC: true
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
       affinity:
         {{- include "nodeaffinity" . | indent 6 }}
       {{- if .Values.image.secretName }}
@@ -45,6 +51,19 @@ spec:
         - containerPort: {{ .Values.service.port }}
           protocol: UDP
         - containerPort: {{ .Values.etcd.port }}
+        securityContext:
+          privileged: false
+          readOnlyRootFilesystem: false
+          allowPrivilegeEscalation: false
+          runAsNonRoot: false
+          runAsUser: 0
+          capabilities:
+                add:
+                - SYS_ADMIN
+                - SYS_RESOURCE
+                - SYS_TIME
+                - NET_BROADCAST
+                - NET_ADMIN
         readinessProbe:
           httpGet:
             port: {{ .Values.service.port }}
@@ -110,11 +129,94 @@ spec:
       {{- if .Values.env }}
 {{ toYaml .Values.env | indent 8 }}
       {{- end }}
+{{- if .Values.exporter.enabled }}
+  {{- if .Values.exporter.env }}
+{{ toYaml .Values.exporter.env | indent 8 }}
+  {{- end }}
+{{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
         - name: ssl
           mountPath: /etc/ssl/certs
+{{- if .Values.exporter.enabled }}
+      - name: skydive-exporter
+        image: {{ .Values.exporter.image.repository }}:{{ .Values.exporter.image.tag }}
+        securityContext:
+          privileged: false
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 1000
+        env:
+        - name: SKYDIVE_ANALYZERS
+          value: {{ template "fullname" . }}-service:{{ .Values.service.port }}
+        - name: SKYDIVE_PIPELINE_SUBSCRIBER_URL
+          value: ws://{{ template "fullname" . }}-service:{{ .Values.service.port }}/ws/subscriber/flow
+        - name: SKYDIVE_PIPELINE_STORE_BUFFERED_FILENAME_PREFIX
+          valueFrom:
+            configMapKeyRef:
+              name: skydive-exporter-s3-configuration
+              key: "objectPrefix"
+        - name: SKYDIVE_PIPELINE_WRITE_S3_ENDPOINT
+          valueFrom: 
+            configMapKeyRef:
+               name: "skydive-exporter-s3-configuration"
+               key: "endpoint"
+        - name: SKYDIVE_PIPELINE_WRITE_S3_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "skydive-exporter-secret"
+              key: "accesskey"
+        - name: SKYDIVE_PIPELINE_WRITE_S3_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "skydive-exporter-secret"
+              key: "secretkey"
+      {{- if .Values.exporter.write.s3.use_api_key }}
+        - name: SKYDIVE_PIPELINE_WRITE_S3_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "skydive-exporter-secret"
+              key: "apikey"
+      {{- end }}
+        - name: SKYDIVE_PIPELINE_CLASSIFY_CLUSTER_NET_MASKS
+          valueFrom:
+            configMapKeyRef:
+              name: skydive-configuration
+              key: "netmasks"
+        - name: SKYDIVE_PIPELINE_STORE_BUFFERED_DIRNAME
+          valueFrom:
+            configMapKeyRef:
+              name: "skydive-exporter-s3-configuration"
+              key: "bucket"
+        - name: SKYDIVE_PIPELINE_WRITE_S3_REGION
+          valueFrom:
+            configMapKeyRef:
+              name: "skydive-exporter-s3-configuration"
+              key: "region"
+      {{- if .Values.exporter.env_exporter }}
+{{ toYaml .Values.exporter.env_exporter | indent 8 }}
+      {{- end }}
+{{- end }}
+     {{- if and .Values.exporter.enabled .Values.exporter.write.s3.installLocalMinio }}
+      - name: skydive-minio
+        image: {{ .Values.exporter.write.s3.minioImage }}:{{ .Values.exporter.write.s3.minioImageTag }}
+        ports:
+        - name: skydive-minio
+          containerPort: 9000
+        env:
+        - name: MINIO_ACCESS_KEY
+          value: {{ .Values.exporter.write.s3.access_key }}
+        - name: MINIO_SECRET_KEY
+          value: {{ .Values.exporter.write.s3.secret_key }}
+        - name: MINIO_DEFAULT_BUCKETS
+          value: {{ .Values.exporter.store.bucket }}
+        - name: MINIO_REGION_NAME
+          value: {{ .Values.exporter.write.s3.region }}
+        volumeMounts:
+        - name: "data"
+          mountPath: "/data"
+    {{- end }}
     {{- if .Values.persistence.enabled }}
       - name: skydive-elasticsearch
         image: {{ .Values.elasticsearch.image.repository }}:{{ .Values.elasticsearch.image.tag }}
@@ -157,4 +259,7 @@ spec:
       - name: ssl
         hostPath:
           path: /etc/ssl/certs
-
+     {{- if and .Values.exporter.enabled .Values.exporter.write.s3.installLocalMinio }}
+      - name: data
+        emptyDir: {}
+    {{- end }}

--- a/templates/exporter-configmap.template.yaml
+++ b/templates/exporter-configmap.template.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.exporter.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: skydive-exporter-s3-configuration
+data:
+  endpoint: {{ .Values.exporter.write.s3.endpoint }}
+  region: {{ .Values.exporter.write.s3.region }}
+  bucket: {{ .Values.exporter.store.bucket }}
+  objectPrefix: {{ .Values.exporter.store.objectPrefix }}
+{{- end }}

--- a/templates/exporter-secrets.yaml
+++ b/templates/exporter-secrets.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.exporter.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: skydive-exporter-secret
+type: Opaque
+data:
+  accesskey: {{ .Values.exporter.write.s3.access_key | b64enc}}
+  secretkey: {{ .Values.exporter.write.s3.secret_key | b64enc}}
+  apikey: {{ .Values.exporter.write.s3.api_key | b64enc}}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -77,3 +77,75 @@ storage:
   elasticsearch:
     port: 9200
     host: 127.0.0.1
+
+exporter:
+  enabled: false
+  image:
+    repository: docker.io/bluesecure/skydive-exporter
+    tag: 1
+  store:
+    bucket: "default"
+    objectPrefix: "default"
+    buffered:
+      max_flows_per_object: 60000
+  write:
+    s3:
+      #endpoint is a required value, pointing to a working Object Store endpoint Example value - "http://localhost:9000"
+      endpoint: "http://127.0.0.1:9000"
+      #installLocalMinio should be set to false if using an external endpoint. If set to true a default minio OS will be installed locally (in a container).
+      #the below minioImage, minioImageTag - are rellevant only in case of installLocalMinio=true - for the default case for testing purposes
+      installLocalMinio: true
+      minioImage: "docker.io/bitnami/minio"
+      minioImageTag: "2019.7.31-debian-9-r1"
+      region: "default"
+      # if use_api_key is set to true - api_key is a required value. Else fill in the access_key and secret_key
+      use_api_key: false
+      api_key: ""
+      # if use_api_key is set to false - fill in the rellevant access_key and secret_key of the used object store
+      access_key: "admin"
+      secret_key: "admin1234"
+
+  env_exporter:
+    # Maximum number of flows per object
+    - name: SKYDIVE_PIPELINE_STORE_BUFFERED_MAX_FLOWS_PER_OBJECT
+      value: "60000"
+
+    # Maximum time period for object
+    - name: SKYDIVE_PIPELINE_STORE_BUFFERED_MAX_SECONDS_PER_OBJECT
+      value: "60"
+
+    - name: SKYDIVE_PIPELINE_STORE_BUFFERED_MAX_FLOW_ARRAY_SIZE
+      value: "100000"
+
+    # New stream (folder) is opened every such period
+    - name: SKYDIVE_PIPELINE_STORE_BUFFERED_MAX_SECONDS_PER_STREAM
+      value: "86400"
+
+  env:
+    # For debug purposes
+    - name: SKYDIVE_LOGGING_LEVEL
+      value: "INFO"
+
+    # the rate in which the agents transfer flow updates to the analyzer
+    # Flows to be updated every 30 seconds (thus, every 60 seconds to defender)
+    - name: SKYDIVE_FLOW_UPDATE
+      value: "30"
+
+    # ANALYZER_STARTUP_CAPTURE_GREMLIN invoke at startup capturing in selected nodes (sets automatic capture on all but he loopback nodes)
+    - name: SKYDIVE_ANALYZER_STARTUP_CAPTURE_GREMLIN
+      value: "G.V().has('Name', NE('lo'))"
+
+    #capture all but skydive (8082)
+    - name: SKYDIVE_ANALYZER_STARTUP_CAPTURE_BPF
+      value: "not (tcp dst port 8082)"
+
+    # DEFAULT_LAYER_KEY_MODE - the layers used to identify a unique flow.
+    - name: SKYDIVE_FLOW_DEFAULT_LAYER_KEY_MODE
+      value: "L3"
+
+    # use pcap userland capture. Not very efficient but works on all linux kernel version
+    - name: SKYDIVE_ANALYZER_STARTUP_CAPTURE_TYPE
+      value: "pcap"
+
+    - name: SKYDIVE_AGENT_CAPTURE_SYN
+      value: "True"


### PR DESCRIPTION
exporter section was added under values.yaml, --set exporter.enabled=true activates the "exporter pre-set" making the SkyDive analyzer start with an additional exporter container. In this case the user also must specify the S3 endpoint and the credentials (either api key or access and secret). By default exporter.enabled is set to false, so installation without --set to this parameter creates default Skydive installation with no changes.